### PR TITLE
PseudoTopProducer bugfix

### DIFF
--- a/TopQuarkAnalysis/TopEventProducers/interface/PseudoTopProducer.h
+++ b/TopQuarkAnalysis/TopEventProducers/interface/PseudoTopProducer.h
@@ -2,34 +2,37 @@
 #define TopQuarkAnalysis_TopEventProducers_PseudoTopProducer_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
 #include "fastjet/JetDefinition.hh"
+#include <set>
 
-class PseudoTopProducer : public edm::EDProducer
+class PseudoTopProducer : public edm::stream::EDProducer<>
 {
 public:
   PseudoTopProducer(const edm::ParameterSet& pset);
   void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
 private:
+  bool isHadron(const int pdgId) const;
   bool isFromHadron(const reco::Candidate* p) const;
   bool isBHadron(const reco::Candidate* p) const;
   bool isBHadron(const unsigned int pdgId) const;
+  void insertAllDaughters(const reco::Candidate* p, std::set<const reco::Candidate*>& list) const;
 
   const reco::Candidate* getLast(const reco::Candidate* p);
   reco::GenParticleRef buildGenParticle(const reco::Candidate* p, reco::GenParticleRefProd& refHandle,
                                         std::auto_ptr<reco::GenParticleCollection>& outColl) const;
-
   typedef reco::Particle::LorentzVector LorentzVector;
 
 private:
-  edm::EDGetTokenT<edm::View<reco::Candidate> > finalStateToken_;
-  edm::EDGetTokenT<edm::View<reco::Candidate> > genParticleToken_;
+  const edm::EDGetTokenT<edm::View<reco::Candidate> > finalStateToken_;
+  const edm::EDGetTokenT<edm::View<reco::Candidate> > genParticleToken_;
   const double leptonMinPt_, leptonMaxEta_, jetMinPt_, jetMaxEta_;
   const double wMass_, tMass_;
 


### PR DESCRIPTION
Our local version of the pseudotop producer was dropping some W candidates.
This was known issue from the end of the last year, which was due to the wrong way to sort minimum |Mlv - Mw|.

The code is now changed to do the pairing depending on the channel, as the common Pseudo top definition is channel specific from the first.
